### PR TITLE
Adds include support to match tests before calling run().

### DIFF
--- a/multi_test_engine/src/MultiTestEngine.php
+++ b/multi_test_engine/src/MultiTestEngine.php
@@ -10,12 +10,21 @@ final class MultiTestEngine extends ArcanistUnitTestEngine {
     $results = array();
 
     foreach ($engines as $engine_or_configuration) {
+      $include = false;
+      $include_report = false;
+      $changedFileMatchesInclude = false;
+
       if (is_array($engine_or_configuration)) {
         $engine_class = $engine_or_configuration['engine'];
-
         foreach ($engine_or_configuration as $configuration => $value) {
-          if ($configuration != 'engine') {
+          if ($configuration != 'engine' &&
+              $configuration != 'include' &&
+              $configuration != 'include_report') {
             $config->setRuntimeConfig($configuration, $value);
+          }
+
+          if ($configuration == 'include' || $configuration == 'include_report') {
+            $$configuration = $value;
           }
         }
       } else {
@@ -23,7 +32,38 @@ final class MultiTestEngine extends ArcanistUnitTestEngine {
       }
 
       $engine = $this->instantiateEngine($engine_class);
-      $results = array_merge($results, $engine->run());
+
+      // If a regex is configured we'll do a match on all changed files to see if there's a match
+      // before calling $engine->run()
+      if ($include) {
+        $include = '/' . $include . '/';
+        foreach ($this->getPaths() as $path) {
+          if (preg_match($include, $path)) {
+            $changedFileMatchesInclude = true;
+            break;
+          }
+        }
+      }
+
+      // No need to execute the unit tests, so bail - but do report that we skipped running tests.
+      if (!$changedFileMatchesInclude) {
+        $test_results = [];
+        // Be silent by default if no files match the include regex, but if the config
+        // includes a bit to see it, output a skip test result for visibility when
+        // no tests match the include regex.
+        if ($include_report) {
+          $skip_test = new ArcanistUnitTestResult();
+          $skip_test->setName("No changed files match " . $include . " - not running " . $engine_class);
+          $skip_test->setResult(ArcanistUnitTestResult::RESULT_SKIP);
+          $test_results[] = $skip_test;
+        }
+
+      // Actually run the tests if we didn't already decide not to run them.
+      } else {
+        $test_results = $engine->run();
+      }
+
+      $results = array_merge($results, $test_results);
     }
 
     return $results;


### PR DESCRIPTION
Updated PR because $$ means I need to name the variable $include not $include_regex. Tested that it's working.