### PR TITLE
Allow specifying the path to the eslint binary in the .arclint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "arcanist-npm-extensions",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Node package wrapper around various arcanist extensions.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Matt Lanter",
+  "license": "ISC"
+}


### PR DESCRIPTION
Allow the eslint linter to take in the path to the eslint binary in the .arclint.  This allows using the locally installed eslint in a project instead of the global one.  The param is optional so if it isn't specified then the behavior is the same as before (using the `eslint` command)

Let me know what you think!

Test plan:
* Verify without it specified it uses the globally installed one.  
* Verify it there is no global one it has the same error message as before.
* Verify if one is specified but invalid it gives an error.
* Verify if one is specified and valid it uses it :) 

Example .arclint:
```
{
  "linters": {
    "javascript": {
      "type": "eslint",
      "include": "/\\.js$/",
      "eslint-binary-path": "node_modules/.bin/eslint"
    }
  }
}
```