### PR TITLE
Update RSpecTestEngine.php

### DIFF
--- a/rspec_test_engine/src/RSpecTestEngine.php
+++ b/rspec_test_engine/src/RSpecTestEngine.php
@@ -30,7 +30,7 @@ final class RSpecTestEngine extends ArcanistUnitTestEngine {
 
     foreach ($json['examples'] as $example) {
       $result = new ArcanistUnitTestResult();
-      $result->setName($example['full_description']);
+      $result->setName(substr($example['full_description'], 0, 250));
 
       if (array_key_exists('run_time', $example)) {
         $result->setDuration($example['run_time']);

--- a/rspec_test_engine/src/RSpecTestEngine.php
+++ b/rspec_test_engine/src/RSpecTestEngine.php
@@ -30,7 +30,7 @@ final class RSpecTestEngine extends ArcanistUnitTestEngine {
 
     foreach ($json['examples'] as $example) {
       $result = new ArcanistUnitTestResult();
-      $result->setName(substr($example['full_description'], 0, 250));
+      $result->setName(substr($example['full_description'], 0, 255));
 
       if (array_key_exists('run_time', $example)) {
         $result->setDuration($example['run_time']);


### PR DESCRIPTION
This is generating errors when RSpec description is larger than 255 chars.
On previous versions was working, now it's preventing me from creating new DIFF's.