### PR TITLE
Allow optional configuration of expected line endings for TAPTestEngine

### DIFF
--- a/tap_test_engine/src/TAPTestEngine.php
+++ b/tap_test_engine/src/TAPTestEngine.php
@@ -5,6 +5,16 @@ final class TAPTestEngine extends ArcanistUnitTestEngine {
   public function run() {
     $projectRoot = $this->getWorkingCopy()->getProjectRoot();
     $command = $this->getConfigurationManager()->getConfigFromAnySource('unit.engine.tap.command');
+    $eol = $this->getConfigurationManager()->getConfigFromAnySource(
+      'unit.engine.tap.eol'
+    );
+
+    /**
+     * Specifying line endings via config is optional, so default to PHP_EOL if not specified.
+     */
+    if (!$eol) {
+      $eol = PHP_EOL;
+    }
 
     $future = new ExecFuture($command);
     $future->setCWD(Filesystem::resolvePath($projectRoot));
@@ -17,16 +27,16 @@ final class TAPTestEngine extends ArcanistUnitTestEngine {
     } while (!$future->isReady());
 
     list($error, $stdout, $stderr) = $future->resolve();
-    return $this->parseOutput($stdout);
+    return $this->parseOutput($stdout, $eol);
   }
 
   public function shouldEchoTestResults() {
     return true;
   }
 
-  private function parseOutput($output) {
+  private function parseOutput($output, $eol) {
     $results = array();
-    $lines = explode(PHP_EOL, $output);
+    $lines = explode($eol, $output);
 
     foreach($lines as $index => $line) {
       preg_match('/^(not ok|ok)\s+\d+\s+-?(.*)/', $line, $matches);


### PR DESCRIPTION
## Summary

Add optional `"unit.engine.tap.eol"` config option for specifying line ending to split results by.
Defaults to `PHP_EOL` if not configured.

## Discussion

Previously `TAPTestEngine` splits the lines of TAP output on `PHP_EOL`. This is a problem if the output it is parsing has any other line endings.  For example, the [Mocha](mochajs.org) test framework for NodeJS always outputs its TAP results with `"\n"` as the line ending, even on Windows.

This revision adds a new, optional, config parameter to allow the line ending to be specified in `.arcconfig`.

E.g. in the case above with `Mocha` tests run through `gulp`, the following config would allow the results to be correctly parsed:

```
  "unit.engine": "TAPTestEngine",
  "unit.engine.tap.command": "gulp test",
  "unit.engine.tap.eol": "\n"
```

## Backwards compatibility

If the config line is not added, the default remains as `PHP_EOL`, so existing users will be unaffected.

## Test Plan

On Windows (i.e. `PHP_EOL` == `"\r\n"`):

* Leave `"unit.engine.tap.eol"` unset (i.e. legacy configs)
  * Test TAP output with `"\r\n"` end-of-lines and check it is parsed correctly
  * Test TAP output with `"\n"` end-of-lines and check it is NOT parsed

* Set `"unit.engine.tap.eol": "\n"` in `.arcconfig` (i.e. different line ending than OS)
  * Test TAP output with `"\r\n"` end-of-lines and check it is now NOT parsed
  * Test TAP output with `"\n"` end-of-lines and check it is parsed correctly

* Set `"unit.engine.tap.eol": "\r\n"` in `.arcconfig` (i.e. explicitly same line ending as OS)
  * Test TAP output with `"\r\n"` end-of-lines and check it is parsed correctly
  * Test TAP output with `"\n"` end-of-lines and check it is NOT parsed